### PR TITLE
fix(budgets): save description when creating multiple budgets via batch

### DIFF
--- a/apps/api/src/modules/budgets/budget.service.ts
+++ b/apps/api/src/modules/budgets/budget.service.ts
@@ -355,6 +355,7 @@ export class BudgetService {
           year,
           type: category.type as unknown as BudgetType,
           userId,
+          description: dto.description,
         },
         select: this.budgetSelect,
       });

--- a/apps/api/src/modules/budgets/dto/create-batch-budget.dto.ts
+++ b/apps/api/src/modules/budgets/dto/create-batch-budget.dto.ts
@@ -1,4 +1,4 @@
-import { IsNumber, IsUUID, Min, Max } from 'class-validator';
+import { IsNumber, IsOptional, IsString, IsUUID, Max, MaxLength, Min } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
 
 export class CreateBatchBudgetDto {
@@ -29,4 +29,10 @@ export class CreateBatchBudgetDto {
   @ApiProperty({ example: 2026 })
   @IsNumber()
   endYear: number;
+
+  @ApiProperty({ description: 'Optional notes about the budget', required: false })
+  @IsOptional()
+  @IsString()
+  @MaxLength(500)
+  description?: string;
 }

--- a/apps/web/src/components/BudgetForm.tsx
+++ b/apps/web/src/components/BudgetForm.tsx
@@ -155,6 +155,7 @@ export function BudgetForm({
           startYear: yearNum,
           endMonth: endMonth as number,
           endYear: endYearNum,
+          description: description || undefined,
         });
         toast.success(
           t('batchCreateSuccess', {

--- a/apps/web/src/types/index.ts
+++ b/apps/web/src/types/index.ts
@@ -167,6 +167,7 @@ export interface CreateBatchBudgetDto {
   startYear: number;
   endMonth: number;
   endYear: number;
+  description?: string;
 }
 
 export interface BatchBudgetResponse {


### PR DESCRIPTION
The batch budget creation flow was missing description support — the DTO had no description field, the service didn't persist it, and the frontend form wasn't sending it. Single-budget creation was unaffected.